### PR TITLE
Using 'text' attribute to report errors to TeamCity, closes #1

### DIFF
--- a/Machine.Specifications.Reporting.Specs/Integration/TeamCityServiceMessageWriterSpecs.cs
+++ b/Machine.Specifications.Reporting.Specs/Integration/TeamCityServiceMessageWriterSpecs.cs
@@ -19,7 +19,7 @@ namespace Machine.Specifications.Reporting.Specs.Integration
           () => Written.Should().EndWith("status=\'ERROR\']");
 
         It should_report_the_error_message =
-          () => { Written.Should().Contain("test=\'test failed\'"); };
+          () => { Written.Should().Contain("text=\'test failed\'"); };
 
         It should_report_error_details =
           () => { Written.Should().Contain("errorDetails=\'details\'"); };

--- a/Machine.Specifications.Reporting/Integration/TeamCity/TeamCityServiceMessageWriter.cs
+++ b/Machine.Specifications.Reporting/Integration/TeamCity/TeamCityServiceMessageWriter.cs
@@ -237,7 +237,7 @@ namespace Machine.Specifications.Reporting.Integration.TeamCity
         {
           WriteMessage(builder =>
           {
-            builder.Append("message test='");
+            builder.Append("message text='");
             AppendEscapedString(builder, message);
             builder.Append("' errorDetails='");
             AppendEscapedString(builder, details);


### PR DESCRIPTION
Fix for #1